### PR TITLE
fix: check filename endings

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path')
 const merge = require('lodash.merge')
 
 function testFileName(fileName) {
-  return fileName.indexOf('.js') > -1 || fileName.indexOf('.ts') > -1
+  return fileName.endsWith('.js') || fileName.endsWith('.ts')
 }
 
 function readJSFilesFromDir(dir) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-autoloader",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "autoload graphql typedefs and resolvers",
   "main": "index.js",
   "scripts": {

--- a/test/read-files/module2/typedefs.js.map
+++ b/test/read-files/module2/typedefs.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"typedefs.js","sourceRoot":""}


### PR DESCRIPTION
Currently very lazy comparison.
Now even more lazy, maybe, just checking that the file name really ends with .js or .ts